### PR TITLE
Log Errors + Support is_broadcaster

### DIFF
--- a/twitch.py
+++ b/twitch.py
@@ -63,7 +63,9 @@ class TwitchIrcBot(SingleServerIRCBot):
             if tag["key"] == "display-name":
                 display_name = tag["value"]
             elif tag["key"] == "mod":
-                is_mod = tag["value"] == '1'
+                is_mod = is_mod or tag["value"] == '1'
+            elif tag["key"] == "badges":
+                is_mod = is_mod or (tag["value"] and "broadcaster/1" in tag["value"])
         channel = event.target[1:] if event.target[0] == "#" else event.target
         return CommandContext(
             author=AuthorInfo(

--- a/twitch.py
+++ b/twitch.py
@@ -3,7 +3,7 @@ import asyncio
 import os
 import threading
 import irc
-from irc.bot import SingleServerIRCBot, SingleServerIRCBot
+from irc.bot import SingleServerIRCBot
 import time
 import requests
 from bot.database import db
@@ -72,6 +72,26 @@ class TwitchIrcBot(SingleServerIRCBot):
             ),
             channel=channel
         )
+
+    def _connect(self):
+        """
+        Establish a connection to the server at the front of the server_list.
+        """
+        server = self.servers.peek()
+        try:
+            self.connect(
+                server.host,
+                server.port,
+                self._nickname,
+                server.password,
+                ircname=self._realname,
+            )
+        except Exception as e:
+            log.error("Error connecting to the server: %s", str(e))
+            pass
+
+    def on_error(self, connection, event):
+        log.info("Got error: %s", str(event))
 
     def on_pubmsg(self, connection, event):
         msg = event.arguments[0]


### PR DESCRIPTION
1. We need to log errors when there's an "error" command issued by the server. The original implementation from `irc.bot` handles this pretty poorly by swallowing the exception. Here, I override the method and provide a different impl to get around this.
2. We can check the **badges** key for the **broadcaster/1** value to see if someone is the broadcaster of the stream. I use this to help say whether or not someone is a "mod" (really we mean "admin", or something who is either mod / broadcaster).